### PR TITLE
chore: remove transformation for SpO2 from sleep intraday

### DIFF
--- a/Grafana_Dashboard/Garmin-Grafana-Dashboard.json
+++ b/Grafana_Dashboard/Garmin-Grafana-Dashboard.json
@@ -2110,31 +2110,14 @@
           }
         },
         {
-          "id": "calculateField",
-          "options": {
-            "alias": "Sleeping SpO2",
-            "mode": "windowFunctions",
-            "reduce": {
-              "reducer": "sum"
-            },
-            "window": {
-              "field": "SpO2",
-              "reducer": "mean",
-              "windowAlignment": "centered",
-              "windowSize": 0.005,
-              "windowSizeMode": "percentage"
-            }
-          }
-        },
-        {
           "id": "filterFieldsByName",
           "options": {
             "include": {
               "names": [
                 "Time",
-                "Sleeping HR",
-                "Sleeping SpO2",
-                "HRV"
+                "SpO2",
+                "HRV",
+                "Sleeping HR"
               ]
             }
           }
@@ -9653,6 +9636,6 @@
   "timezone": "browser",
   "title": "Garmin Stats",
   "uid": "feiibsx498gsgb",
-  "version": 98,
+  "version": 99,
   "weekStart": ""
 }

--- a/Grafana_Dashboard/Garmin-Grafana-Dashboard.json
+++ b/Grafana_Dashboard/Garmin-Grafana-Dashboard.json
@@ -2138,24 +2138,6 @@
               ]
             }
           }
-        },
-        {
-          "id": "filterByValue",
-          "options": {
-            "filters": [
-              {
-                "config": {
-                  "id": "greater",
-                  "options": {
-                    "value": 0
-                  }
-                },
-                "fieldName": "Sleeping SpO2"
-              }
-            ],
-            "match": "any",
-            "type": "include"
-          }
         }
       ],
       "transparent": true,


### PR DESCRIPTION
This fixes the sleep intraday stats if you have SpO2 checks set to manual instead of overnight