### PR TITLE
fix: better easy install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+garminconnect-tokens/

--- a/easy-install.sh
+++ b/easy-install.sh
@@ -31,12 +31,9 @@ echo "Renaming compose-example.yml to compose.yml..."
 mv compose-example.yml compose.yml
 
 echo "Replacing {DS_GARMIN_STATS} variable with garmin_influxdb in the dashboard JSON..."
-# Check if the OS is macOS (Darwin)
 if [[ "$OSTYPE" == "darwin"* ]]; then
-    # macOS sed requires an extension for -i, use '' for no backup
     sed -i '' 's/\${DS_GARMIN_STATS}/garmin_influxdb/g' ./Grafana_Dashboard/Garmin-Grafana-Dashboard.json
 else
-    # Linux sed works without an extension for -i
     sed -i 's/\${DS_GARMIN_STATS}/garmin_influxdb/g' ./Grafana_Dashboard/Garmin-Grafana-Dashboard.json
 fi
 

--- a/easy-install.sh
+++ b/easy-install.sh
@@ -24,7 +24,7 @@ fi
 echo "Creating garminconnect-tokens directory..."
 mkdir -p garminconnect-tokens
 
-# echo "Setting ownership of garminconnect-tokens to UID 1000...(matching grafana-data-fetch container's internal user)"
+echo "Setting ownership of garminconnect-tokens to UID 1000...(matching grafana-data-fetch container's internal user)"
 chown -R 1000:1000 garminconnect-tokens || { echo "Permission change failed - you may need to run this as sudo?. Exiting."; exit 1; }
 
 echo "Renaming compose-example.yml to compose.yml..."

--- a/easy-install.sh
+++ b/easy-install.sh
@@ -24,14 +24,21 @@ fi
 echo "Creating garminconnect-tokens directory..."
 mkdir -p garminconnect-tokens
 
-echo "Setting ownership of garminconnect-tokens to UID 1000...(matching grafana-data-fetch container's internal user)"
+# echo "Setting ownership of garminconnect-tokens to UID 1000...(matching grafana-data-fetch container's internal user)"
 chown -R 1000:1000 garminconnect-tokens || { echo "Permission change failed - you may need to run this as sudo?. Exiting."; exit 1; }
 
 echo "Renaming compose-example.yml to compose.yml..."
 mv compose-example.yml compose.yml
 
 echo "Replacing {DS_GARMIN_STATS} variable with garmin_influxdb in the dashboard JSON..."
-sed -i 's/\${DS_GARMIN_STATS}/garmin_influxdb/g' ./Grafana_Dashboard/Garmin-Grafana-Dashboard.json
+# Check if the OS is macOS (Darwin)
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    # macOS sed requires an extension for -i, use '' for no backup
+    sed -i '' 's/\${DS_GARMIN_STATS}/garmin_influxdb/g' ./Grafana_Dashboard/Garmin-Grafana-Dashboard.json
+else
+    # Linux sed works without an extension for -i
+    sed -i 's/\${DS_GARMIN_STATS}/garmin_influxdb/g' ./Grafana_Dashboard/Garmin-Grafana-Dashboard.json
+fi
 
 echo "🐳 Pulling the latest thisisarpanghosh/garmin-fetch-data Docker image..."
 docker pull thisisarpanghosh/garmin-fetch-data:latest || { echo "Docker pull failed. Do you have docker installed and can run docker commands?"; exit 1; }

--- a/garmin-fetch.py
+++ b/garmin-fetch.py
@@ -1013,4 +1013,4 @@ else:
             logging.info(f"No new data found : Current watch and influxdb sync time is {last_watch_sync_time_UTC} UTC")
         logging.info(f"waiting for {UPDATE_INTERVAL_SECONDS} seconds before next automatic update calls")
         time.sleep(UPDATE_INTERVAL_SECONDS)
-        
+


### PR DESCRIPTION
This patch do these things:

- chmod +x for `easy-install.sh` for easy use
- for macOS sed is not the same this patch fix it
- add .gitignore for better dev experience
- lint last line for garmin-fetch.py