### PR TITLE
Update Garmin-Grafana-Dashboard.json

### DIFF
--- a/Grafana_Dashboard/Garmin-Grafana-Dashboard.json
+++ b/Grafana_Dashboard/Garmin-Grafana-Dashboard.json
@@ -7970,7 +7970,8 @@
           "calcs": [
             "min",
             "max",
-            "mean"
+            "mean",
+            "last"
           ],
           "displayMode": "table",
           "placement": "bottom",


### PR DESCRIPTION
Shows last predicted Time. This should be the current prediction for your race values. Current prediction might not be the lowest or maximum ever time presented.