### PR TITLE
Update Garmin-Grafana-Dashboard.json

### DIFF
--- a/Grafana_Dashboard/Garmin-Grafana-Dashboard.json
+++ b/Grafana_Dashboard/Garmin-Grafana-Dashboard.json
@@ -13612,6 +13612,11 @@
             "value": "Europe/Budapest"
           },
           {
+            "selected": true,
+            "text": "Europe/London",
+            "value": "Europe/London"
+          },
+          {
             "selected": false,
             "text": "America/Toronto",
             "value": "America/Toronto"


### PR DESCRIPTION
Adds Europe/London Timezone to grafana dashboard. It's kinda of more Default on europe than Budapest.