### PR TITLE
use a recent demo timestamp

### DIFF
--- a/src/garmin_grafana/garmin_fetch.py
+++ b/src/garmin_grafana/garmin_fetch.py
@@ -103,7 +103,7 @@ try:
             )
     demo_point = {
     'measurement': 'DemoPoint',
-    'time': (datetime.now() - timedelta(minutes=1)).isoformat(),
+    'time': (datetime.now(pytz.utc) - timedelta(minutes=1)).isoformat(timespec='seconds'),
     'tags': {'DemoTag': 'DemoTagValue'},
     'fields': {'DemoField': 0}
      }


### PR DESCRIPTION
Currently if you have a retention period set on the influx database, the script will fail to start with the DemoPoint with the following error
```
garmin-fetch influxdb.exceptions.InfluxDBClientError: InfluxDB connection failed:400:
 {"error":"partial write: points beyond retention policy or outside permissible write window 
dropped=1 for database: GarminStats for retention policy: 2_years"}
```

Using a recent timestamp for demoing resolves this.