### PR TITLE
Use activity type if name is missing

### DIFF
--- a/src/garmin_grafana/garmin_bulk_importer.py
+++ b/src/garmin_grafana/garmin_bulk_importer.py
@@ -187,8 +187,9 @@ class GarminBulkExport:
             a["startTimeGMT"] = datetime.fromtimestamp(
                 a["startTimeGmt"] / 1000, tz=timezone.utc
             ).strftime("%Y-%m-%d %H:%M:%S")
-            a["activityType"] = {"typeKey": a["activityType"]}
-            a["activityName"] = a["name"]
+            activity_type = a["activityType"]
+            a["activityName"] = a.get("name", activity_type)
+            a["activityType"] = {"typeKey": activity_type}
             a["averageSpeed"] = a.get("avgSpeed")
             a["maxHR"] = a.get("maxHr")
             a["averageHR"] = a.get("avgHr")


### PR DESCRIPTION
Fixes this issue: https://github.com/arpanghosh8453/garmin-grafana/pull/191#issuecomment-3798657031
Some activities don't have a name: https://github.com/arpanghosh8453/garmin-grafana/pull/191#issuecomment-3799077668