### PR TITLE
feat: Add Lifestyle Journaling data support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY pyproject.toml /app/
 COPY uv.lock /app/
 
 WORKDIR /app
-RUN uv sync --locked
+RUN uv sync
 
 RUN groupadd --gid 1000 appuser && useradd --uid 1000 --gid appuser --shell /bin/bash --create-home appuser && chown -R appuser:appuser /app
 USER appuser

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = "==3.13.*"
 dependencies = [
     "dotenv==0.9.9",
     "fitparse==1.2.0",
-    "garminconnect==0.2.26",
+    "garminconnect>=0.2.35",
     "influxdb==5.3.2",
     "influxdb3-python==0.12.0",
     "pandas==2.2.3",


### PR DESCRIPTION


This PR adds support for fetching and storing Lifestyle Journaling data from Garmin Connect.

What is Lifestyle Journaling?
Garmin's Lifestyle Logging feature allows users to track daily behaviors (caffeine, alcohol, sleep habits, etc.) and see their impact on health metrics. This data was previously not synced by garmin-grafana.

Changes Made
src/garmin_grafana/garmin_fetch.py
Added 
get_lifestyle_data(date_str)
 function that:
Fetches data using garmin_obj.get_lifestyle_logging_data(date_str)
Parses dailyLogsReport entries
Extracts behavior name, category, log status, and details (amounts/subtypes)
Creates InfluxDB points with measurement LifestyleJournal
Integrated into 
daily_fetch_write()
 when 'lifestyle' is in FETCH_SELECTION
Added 'lifestyle' to the default FETCH_SELECTION
pyproject.toml
 (requires discussion)
Updated garminconnect from ==0.2.26 to >=0.2.35
Required because get_lifestyle_logging_data() was added in v0.2.35 (PR #304)
Dockerfile
 (requires discussion)
Changed uv sync --locked to uv sync
Required to allow the dependency update during build
New InfluxDB Measurement
Measurement: LifestyleJournal

Field	Type	Description
Behavior	string	e.g., "Morning Caffeine", "Alcohol"
LogStatus	string	"YES" or "NO"
Category	string	"LIFESTYLE", "SLEEP_RELATED", etc.
TotalAmount	int	Sum of all detail amounts
{SUBTYPE}_Amount	int	e.g., COFFEE_Amount = 2
Tags: Device, Database_Name, Behavior, Category

Testing
Tested locally via Docker
Successfully synced Lifestyle Journaling data to InfluxDB
Backfill works with FETCH_SELECTION=lifestyle
Backfill Command
bash
docker compose run --rm \
  -e MANUAL_START_DATE=YYYY-MM-DD \
  -e MANUAL_END_DATE=YYYY-MM-DD \
  -e FETCH_SELECTION=lifestyle \
  garmin-fetch-data

⚠️ Discussion Points
1. Dependency Version Bump (garminconnect>=0.2.35)
The get_lifestyle_logging_data() method only exists in v0.2.35+. Options:

Option A: Accept the version bump (recommended - it's a minor version update)
Option B: Keep the old version and use connectapi() directly (but the correct URL is not documented)
2. Dockerfile Change (uv sync vs uv sync --locked)
Removing --locked allows the dependency to update. This might not be desired for reproducible builds. Options:

Option A: Update 
uv.lock
 in this PR to include the new version
Option B: Maintainer regenerates the lockfile

To be honest I got ai to help with this... Option A sounds the most logical way forward.