### PR TITLE
feat: Add Lifestyle Journaling data support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = "==3.13.*"
 dependencies = [
     "dotenv==0.9.9",
     "fitparse==1.2.0",
-    "garminconnect==0.2.26",
+    "garminconnect>=0.2.35",
     "influxdb==5.3.2",
     "influxdb3-python==0.12.0",
     "pandas==2.2.3",

--- a/src/garmin_grafana/garmin_fetch.py
+++ b/src/garmin_grafana/garmin_fetch.py
@@ -57,7 +57,7 @@ MAX_CONSECUTIVE_500_ERRORS = int(os.getenv("MAX_CONSECUTIVE_500_ERRORS", 10)) # 
 INFLUXDB_ENDPOINT_IS_HTTP = False if os.getenv("INFLUXDB_ENDPOINT_IS_HTTP") in ['False','false','FALSE','f','F','no','No','NO','0'] else True # optional
 GARMIN_DEVICENAME_AUTOMATIC = False if GARMIN_DEVICENAME != "Unknown" else True # optional
 UPDATE_INTERVAL_SECONDS = int(os.getenv("UPDATE_INTERVAL_SECONDS", 300)) # optional
-FETCH_SELECTION = os.getenv("FETCH_SELECTION", "daily_avg,sleep,steps,heartrate,stress,breathing,hrv,fitness_age,vo2,activity,race_prediction,body_composition") # additional available values are lactate_threshold,training_status,training_readiness,hill_score,endurance_score,blood_pressure,hydration,solar_intensity which you can add to the list seperated by , without any space
+FETCH_SELECTION = os.getenv("FETCH_SELECTION", "daily_avg,sleep,steps,heartrate,stress,breathing,hrv,fitness_age,vo2,activity,race_prediction,body_composition,lifestyle") # additional available values are lactate_threshold,training_status,training_readiness,hill_score,endurance_score,blood_pressure,hydration,solar_intensity which you can add to the list seperated by , without any space
 LACTATE_THRESHOLD_SPORTS = os.getenv("LACTATE_THRESHOLD_SPORTS", "RUNNING").upper().split(",") # Garmin currently implements RUNNING, but has provisions for CYCLING, and SWIMMING
 KEEP_FIT_FILES = True if os.getenv("KEEP_FIT_FILES") in ['True', 'true', 'TRUE','t', 'T', 'yes', 'Yes', 'YES', '1'] else False # optional
 FIT_FILE_STORAGE_LOCATION = os.getenv("FIT_FILE_STORAGE_LOCATION", os.path.join(os.path.expanduser("~"), "fit_filestore"))
@@ -1206,6 +1206,59 @@ def get_solar_intensity(date_str):
         logging.warning(f"No Solar Intensity data available for date {date_str}")
     return points_list
 
+# %%
+def get_lifestyle_data(date_str):
+    points_list = []
+    try:
+        logging.info(f"Fetching Lifestyle Journaling data for date {date_str}")
+        journal_data = garmin_obj.get_lifestyle_logging_data(date_str)
+        
+        daily_logs = journal_data.get('dailyLogsReport', [])
+        
+        for log in daily_logs:
+            behavior_name = log.get('name') or log.get('behavior')
+            if not behavior_name:
+                continue
+
+            category = log.get('category', 'UNKNOWN')
+            log_status = log.get('logStatus')
+            details = log.get('details', [])
+            
+            # status: 1 for YES, 0 for NO
+            status = 1 if log_status == "YES" else 0
+            
+            # value: sum of detail amounts if available, else 0.0
+            value = 0.0
+            if details:
+                for detail in details:
+                    amount = detail.get('amount')
+                    if amount is not None:
+                        value += float(amount)
+
+            fields = {
+                "status": status,
+                "value": value
+            }
+
+            points_list.append({
+                "measurement": "LifestyleJournal",
+                "time": pytz.timezone("UTC").localize(datetime.strptime(date_str, "%Y-%m-%d")).isoformat(),
+                "tags": {
+                    "Device": GARMIN_DEVICENAME,
+                    "Database_Name": INFLUXDB_DATABASE,
+                    "behavior": behavior_name,
+                    "category": category
+                },
+                "fields": fields
+            })
+            
+        logging.info(f"Success : Fetching Lifestyle Journaling data for date {date_str}")
+
+    except Exception as e:
+        logging.warning(f"Failed to fetch Lifestyle Journaling data for date {date_str}: {e}")
+    
+    return points_list
+
 
 # %%
 def daily_fetch_write(date_str):
@@ -1272,6 +1325,8 @@ def daily_fetch_write(date_str):
         write_points_to_influxdb(fetch_activity_GPS(activity_with_gps_id_dict))
     if 'solar_intensity' in FETCH_SELECTION:
         write_points_to_influxdb(get_solar_intensity(date_str))
+    if 'lifestyle' in FETCH_SELECTION:
+        write_points_to_influxdb(get_lifestyle_data(date_str))
 
 
 # %%

--- a/uv.lock
+++ b/uv.lock
@@ -76,7 +76,7 @@ dependencies = [
 requires-dist = [
     { name = "dotenv", specifier = "==0.9.9" },
     { name = "fitparse", specifier = "==1.2.0" },
-    { name = "garminconnect", specifier = "==0.2.26" },
+    { name = "garminconnect", specifier = ">=0.2.35" },
     { name = "influxdb", specifier = "==5.3.2" },
     { name = "influxdb3-python", specifier = "==0.12.0" },
     { name = "pandas", specifier = "==2.2.3" },
@@ -84,28 +84,28 @@ requires-dist = [
 
 [[package]]
 name = "garminconnect"
-version = "0.2.26"
+version = "0.2.38"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "garth" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/66/00/bf6114f834b4a1b4922eb413cbcdd68494a2e02cdf0aff4c4d7bcd2ad5f5/garminconnect-0.2.26.tar.gz", hash = "sha256:079692b9829f8e9aaeea5dcbcac2b3fa0851ac027432f561cb04441700ece025", size = 147924, upload_time = "2025-04-04T13:00:59.026Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/b5/c2d3c7fb53c98f74ef208b44b686e48f01cb6434d091f66593e29fd4d2ed/garminconnect-0.2.38.tar.gz", hash = "sha256:53f0d73e821dfa9e93731a6a1c81c34e689ce157c2751edd22dd462d4e4f9e04", size = 37502, upload_time = "2026-01-04T12:08:57.563Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/60/e971ccb635028c2d9cb2bd4d234990664af84f3fe9b998f7df3de8f695da/garminconnect-0.2.26-py3-none-any.whl", hash = "sha256:41ffbca72c9fb8679ee5c4aaa5270f9fc68d375a8055688cfcf80c7a4dd2c067", size = 84222, upload_time = "2025-04-04T13:00:56.426Z" },
+    { url = "https://files.pythonhosted.org/packages/91/dc/9e0b1eee113fedfefd6577de45205e33505fcdc1520d4d28ee4c339e9862/garminconnect-0.2.38-py3-none-any.whl", hash = "sha256:801f64834d8d2ff41f10679e4111fc157312550980b0e29b0c2f263fd628a604", size = 32733, upload_time = "2026-01-04T12:08:55.45Z" },
 ]
 
 [[package]]
 name = "garth"
-version = "0.5.3"
+version = "0.5.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "requests" },
     { name = "requests-oauthlib" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/92/60/339de0e3d01d2a4dac9f44f7c50d094b949c963573ddc5bb0b58eb54c9e3/garth-0.5.3.tar.gz", hash = "sha256:732a970a47e4a5def556a82e645380e1b3bf74e90a059904cc9e8154b0815850", size = 1752258, upload_time = "2025-03-13T04:27:58.139Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/1a/e559feb5efd53e9a5d15c28007a714e240a51363c79a306727977fe1999b/garth-0.5.21.tar.gz", hash = "sha256:8d979595d1d4ea23a1b466ab4a60955d139b71f886f46490be140fcee584dab4", size = 1840358, upload_time = "2026-01-07T23:12:33.828Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/ec/6e2e573fd11e486d92a7ee805b031325d88036690d076c2cdd1661915a41/garth-0.5.3-py3-none-any.whl", hash = "sha256:c5539bd1b2078ffc0188e7de93c823f06b7fe74399032bd35a2d259133bdf464", size = 24530, upload_time = "2025-03-13T04:27:56.717Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/14/b7c77f363ff04cc0c57991277b8c3564df5210b0879894e2033f90f55ff5/garth-0.5.21-py3-none-any.whl", hash = "sha256:24b8c517ef24ef030bca14cf4e8d7ad7a191d9bc60ece6077fec6ea743a5d039", size = 33265, upload_time = "2026-01-07T23:12:32.069Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Add Lifestyle Journaling support

Hi @arpanghosh8453, this is my second attempt on adding support for Garmin's (newish) **Lifestyle Logging** feature — the journaling tool in Garmin Connect where you track daily behaviors like caffeine, alcohol, sleep habits, etc. Hopefully when I get some time to figure out Grafana I'll be able to see coffee intake vs stress or alcohol vs stress vs body battery vs hvr. 

## What it does

- Fetches lifestyle journaling data via `garmin_obj.get_lifestyle_logging_data(date_str)`
- Stores each logged behavior as a point in a new `LifestyleJournal` measurement
- Integrates into the existing `FETCH_SELECTION` system ([lifestyle](file:///c:/Users/DanielWhelan/garmin/garmin-grafana/src/garmin_grafana/garmin_fetch.py#1210-1267))

## InfluxDB Schema

**Measurement:** `LifestyleJournal`

**Tags:**
- `Device`, `Database_Name` (standard)
- `Behavior` — e.g. "Morning Caffeine", "Pet in Bedroom", "Alcohol"
- `Category` — e.g. "LIFESTYLE", "SLEEP_RELATED", "SELF_CARE"

**Fields:**
- `LogStatus` (boolean) — `true` if logged as YES, `false` otherwise
- `TotalAmount` (int) — sum of detail amounts (for quantity-based behaviors)
- `{SUBTYPE}_Amount` (int) — e.g. `COFFEE_Amount = 2`

^^ Thanks for the info, very helpful. 

## Files changed

- **[garmin_fetch.py](file:///c:/Users/DanielWhelan/garmin/garmin-grafana/src/garmin_grafana/garmin_fetch.py)** — new [get_lifestyle_data()](file:///c:/Users/DanielWhelan/garmin/garmin-grafana/src/garmin_grafana/garmin_fetch.py#1210-1267) function + integration into [daily_fetch_write()](file:///c:/Users/DanielWhelan/garmin/garmin-grafana/src/garmin_grafana/garmin_fetch.py#1270-1336)
- **[pyproject.toml](file:///c:/Users/DanielWhelan/garmin/garmin-grafana/pyproject.toml)** — bumped `garminconnect` to `>=0.2.35` (needed for `get_lifestyle_logging_data()`, added in [PR #304](https://github.com/cyberjunky/python-garminconnect/pull/304))
- **[uv.lock](file:///c:/Users/DanielWhelan/garmin/garmin-grafana/uv.lock)** — regenerated to match the new dependency
- **[Dockerfile](file:///c:/Users/DanielWhelan/garmin/garmin-grafana/Dockerfile)** — no changes (kept `--locked`)

## Testing

Tested on my own setup running via Docker. Confirmed data syncs to InfluxDB and is queryable in Grafana. Backfill works with:
```bash
docker compose run --rm -e FETCH_SELECTION=lifestyle -e MANUAL_START_DATE=2024-01-01 -e MANUAL_END_DATE=2026-02-10 garmin-fetch-data
```
## Database

Here is a copy of some data within the new database table 'LifestyleJournal'
[DB Home_GarminStats.csv](https://github.com/user-attachments/files/25208524/DB.Home_GarminStats.csv)


## JSON 

Totally separate but I'll put it here, here is a copy of a JSON for all Gramin Lifestyle options along with some custom.
[lifestyle_data_2026-02-09.json](https://github.com/user-attachments/files/25208515/lifestyle_data_2026-02-09.json)

## Where is the Grafana dashboard data? 

I thought it would be a good idea to start harvesting the data and then at a later date start adding good use cases. At least the ground work has been done collecting the data. I hope this is good enough for a PR. What do you think?
