### PR TITLE
feat: Added average temperature deviation during sleep

### DIFF
--- a/src/garmin_grafana/garmin_fetch.py
+++ b/src/garmin_grafana/garmin_fetch.py
@@ -223,7 +223,10 @@ def get_daily_stats(date_str):
                 "restingHeartRate": stats_json.get("restingHeartRate"),
                 "minAvgHeartRate": stats_json.get("minAvgHeartRate"),
                 "maxAvgHeartRate": stats_json.get("maxAvgHeartRate"),
-                
+
+                "avgSkinTempDeviationC": stats_json.get("avgSkinTempDeviationC"),
+                "avgSkinTempDeviationF": stats_json.get("avgSkinTempDeviationF"),
+
                 "stressDuration": stats_json.get("stressDuration"),
                 "restStressDuration": stats_json.get("restStressDuration"),
                 "activityStressDuration": stats_json.get("activityStressDuration"),
@@ -318,7 +321,9 @@ def get_sleep_data(date_str):
             "restlessMomentsCount": all_sleep_data.get("restlessMomentsCount"),
             "avgOvernightHrv": all_sleep_data.get("avgOvernightHrv"),
             "bodyBatteryChange": all_sleep_data.get("bodyBatteryChange"),
-            "restingHeartRate": all_sleep_data.get("restingHeartRate")
+            "restingHeartRate": all_sleep_data.get("restingHeartRate"),
+            "avgSkinTempDeviationC": all_sleep_data.get("avgSkinTempDeviationC"),
+            "avgSkinTempDeviationF": all_sleep_data.get("avgSkinTempDeviationF")
             }
         })
     sleep_movement_intraday = all_sleep_data.get("sleepMovement")


### PR DESCRIPTION
Issue : https://github.com/arpanghosh8453/garmin-grafana/issues/150

## Context
If you have a [Garmin compatible device](https://support.garmin.com/fr-FR/?faq=RDXq6E5Iaq9rD1l1kTObf6), you can see your temperature deviation during sleep each day.
<img width="1367" height="692" alt="image" src="https://github.com/user-attachments/assets/4943e8a0-4c8b-49f7-b5ff-afc15906b62d" />

This PR aims to add this measurement into the `garmin_fetch.py` allowing to vizualise it on Grafana.
(cc @arpanghosh8453 @gompstar)