### PR TITLE
feat: Added description field to ActivitySummary

### DIFF
--- a/src/garmin_grafana/garmin_fetch.py
+++ b/src/garmin_grafana/garmin_fetch.py
@@ -653,6 +653,7 @@ def get_activity_summary(date_str):
                     "Activity_ID": activity.get('activityId'),
                     'Device_ID': activity.get('deviceId'),
                     'activityName': activity.get('activityName'),
+                    'description': activity.get('description'),
                     'activityType': (activity.get('activityType') or {}).get('typeKey',None),
                     'distance': activity.get('distance'),
                     'elapsedDuration': activity.get('elapsedDuration'),


### PR DESCRIPTION
## Context
When you finish an activity, you can add a description to it.

<img width="646" height="257" alt="image" src="https://github.com/user-attachments/assets/a57089a6-71be-4a4b-a5b6-bbca4d4cb2d7" />

This PR aims to add said activity description into the garmin_fetch.py for `ActivitySummary` allowing to vizualise it on Grafana.
(cc @arpanghosh8453 )