### PR TITLE
fix: Adding advanced running metrics to ActivityGPS as well

### DIFF
--- a/src/garmin_grafana/garmin_fetch.py
+++ b/src/garmin_grafana/garmin_fetch.py
@@ -752,7 +752,11 @@ def fetch_activity_GPS(activityIDdict): # Uses FIT file by default, falls back t
                                     "Fractional_Cadence": parsed_record.get('fractional_cadence', None),
                                     "Temperature": parsed_record.get('temperature', None),
                                     "Accumulated_Power": parsed_record.get('accumulated_power', None),
-                                    "Power": parsed_record.get('power', None)
+                                    "Power": parsed_record.get('power', None),
+                                    "Vertical_Oscillation": parsed_record.get('vertical_oscillation', None),
+                                    "Stance_Time": parsed_record.get('stance_time', None),
+                                    "Vertical_Ratio": parsed_record.get('vertical_ratio', None),
+                                    "Step_Length": parsed_record.get('step_length', None)
                                 }
                             }
                             points_list.append(point)


### PR DESCRIPTION
## Context
Last [PR](https://github.com/arpanghosh8453/garmin-grafana/pull/207), I only added average advanced running metrics. I forgot to add those in the ActivityGPS measurement as well.
<img width="1918" height="367" alt="image" src="https://github.com/user-attachments/assets/f932900b-50b6-4d62-a632-8d99d9af7390" />

This PR adds it.
(cc @arpanghosh8453)