### PR TITLE
fix(dashboard): set min:0 for gauge normalization

### DIFF
--- a/Grafana_Dashboard/Garmin-Grafana-Dashboard.json
+++ b/Grafana_Dashboard/Garmin-Grafana-Dashboard.json
@@ -6902,6 +6902,10 @@
                 "value": 179
               },
               {
+                "id": "min",
+                "value": 0
+              },
+              {
                 "id": "color",
                 "value": {
                   "fixedColor": "semi-dark-green",
@@ -6953,6 +6957,10 @@
                 "value": 186
               },
               {
+                "id": "min",
+                "value": 0
+              },
+              {
                 "id": "color",
                 "value": {
                   "fixedColor": "purple",
@@ -6974,6 +6982,10 @@
               {
                 "id": "custom.width",
                 "value": 199
+              },
+              {
+                "id": "min",
+                "value": 0
               },
               {
                 "id": "color",


### PR DESCRIPTION
## Summary
Set `min: 0` override for Steps, Distance Covered and High Stress Duration fields to normalize gauge visualizations.

## Problem
Without explicit min value, Grafana auto-scales the gauge range based on data, causing bars to start from non-zero positions. This makes visual comparison misleading - shorter bars don't actually represent smaller values proportionally.

## Example (Steps column)
When Steps values range from 7000-22000, the gauge might auto-scale and start from 6000 instead of 0. A value of 8000 steps would show as a tiny bar, while 22000 fills the entire gauge - visually suggesting the smaller value is ~10% of the max, when it's actually ~36%.

## Solution
By setting `min: 0`, all bars start from the same baseline, ensuring accurate visual representation of data magnitude and enabling proper comparison between rows.

## Fields Affected
- Steps
- Distance Covered  
- High Stress Duration

## Visual comparison

<img width="928" height="250" alt="Screenshot_20260227_073923" src="https://github.com/user-attachments/assets/b0620f1f-4f21-4faf-9425-c65d52e1c5b3" />
<img width="928" height="250" alt="Screenshot_20260227_074019" src="https://github.com/user-attachments/assets/16e0aba4-c1b6-4ede-a37f-adb60b30e339" />

