### PR TITLE
Fix hrTimeInZone field type conflict with InfluxDB 1.x

### DIFF
--- a/src/garmin_grafana/garmin_fetch.py
+++ b/src/garmin_grafana/garmin_fetch.py
@@ -666,11 +666,11 @@ def get_activity_summary(date_str):
                     'maxHR': activity.get('maxHR'),
                     'locationName': activity.get('locationName'),
                     'lapCount': activity.get('lapCount'),
-                    'hrTimeInZone_1': int(val) if (val := activity.get('hrTimeInZone_1')) is not None else None,
-                    'hrTimeInZone_2': int(val) if (val := activity.get('hrTimeInZone_2')) is not None else None,
-                    'hrTimeInZone_3': int(val) if (val := activity.get('hrTimeInZone_3')) is not None else None,
-                    'hrTimeInZone_4': int(val) if (val := activity.get('hrTimeInZone_4')) is not None else None,
-                    'hrTimeInZone_5': int(val) if (val := activity.get('hrTimeInZone_5')) is not None else None,
+                    'hrTimeInZone_1': activity.get('hrTimeInZone_1'),
+                    'hrTimeInZone_2': activity.get('hrTimeInZone_2'),
+                    'hrTimeInZone_3': activity.get('hrTimeInZone_3'),
+                    'hrTimeInZone_4': activity.get('hrTimeInZone_4'),
+                    'hrTimeInZone_5': activity.get('hrTimeInZone_5'),
                 }
             })
             points_list.append({


### PR DESCRIPTION
## Summary

- Remove unnecessary `int()` cast from `hrTimeInZone_1` through `hrTimeInZone_5` in `ActivitySummary` (lines 669-673 of `garmin_fetch.py`)
- Use `activity.get()` directly — consistent with all other fields (`distance`, `averageHR`, `calories`, etc.)

## Problem

InfluxDB 1.x is strict about field types. The `int()` cast forces these fields to always be written as integer, but if the database already has them stored as `float` (from a previous write where the API returned a decimal value), InfluxDB rejects the entire record:

```
field type conflict: input field "hrTimeInZone_1" on measurement "ActivitySummary"
is type integer, already exists as type float dropped=1
```

GPS data and END markers write fine, but activity details (name, type, distance, duration, HR, calories) are **silently lost**.

## Fix

```python
# Before (explicit int cast — can cause type conflicts):
'hrTimeInZone_1': int(val) if (val := activity.get('hrTimeInZone_1')) is not None else None,

# After (pass through raw API value — consistent with other fields):
'hrTimeInZone_1': activity.get('hrTimeInZone_1'),
```

By removing the cast entirely, the value type matches whatever InfluxDB already has stored, avoiding conflicts in both directions (float→int and int→float).

Fixes #225