### PR TITLE
feat: Track Strength Training Workouts via Garmin API (fixes #189)

### DIFF
--- a/src/garmin_grafana/garmin_fetch.py
+++ b/src/garmin_grafana/garmin_fetch.py
@@ -785,7 +785,7 @@ def get_strength_training_data(strength_activity_id_dict):
                 }
                 points_list.append({
                     "measurement": "StrengthHRZones",
-                    "time": (activity_start_time + timedelta(milliseconds=zone_number)).isoformat(),
+                    "time": (activity_start_time + timedelta(milliseconds=int(zone_number))).isoformat(),
                     "tags": {
                         "Device": GARMIN_DEVICENAME,
                         "Database_Name": INFLUXDB_DATABASE,


### PR DESCRIPTION
## Summary

Adds support for tracking **strength/weight training workouts** using the Garmin Connect API, as proposed in #189 by @vchatela and @Gandalf-the-Blue.

Uses **API data instead of FIT files**, so corrected exercise names from Garmin Connect are reflected (FIT files only contain raw watch guesses).

## New InfluxDB Measurements

| Measurement | Level | Key Fields |
|---|---|---|
| `StrengthExerciseSummary` | Per exercise group | Category, SubCategory, TotalReps, TotalSets, MaxWeight_kg, Volume_kg, Duration_ms |
| `StrengthExerciseSet` | Per individual set | ExerciseName, Reps, Weight_kg, Weight_g, Duration_s, SetOrder |
| `StrengthHRZones` | Per HR zone | ZoneNumber, SecsInZone, ZoneLowBoundary |

Also enriches `ActivitySummary` with: `totalSets`, `totalReps`, `activeSets`, `aerobicTrainingEffect`, `anaerobicTrainingEffect`, `activityTrainingLoad`, `moderateIntensityMinutes`, `vigorousIntensityMinutes`.

## API Endpoints Used

- `get_activities_by_date()` — already used, now also extracts `summarizedExerciseSets` for strength activities
- `get_activity_exercise_sets(activity_id)` — fetches individual set-level data with corrected exercise names
- `get_activity_hr_in_timezones(activity_id)` — fetches HR zone distribution

## No Config Change Needed

Strength data is **automatically fetched** whenever the existing `activity` fetch selection finds a `strength_training` activity. No new environment variable required.

## Live Test Results

Tested against a real strength training workout (Activity ID: 22204950240, `Musculation`, 2026-03-17).

### Summarized Exercise Sets (from activity list API)
```
totalSets=32 totalReps=757 activeSets=32
aerobicTE=3.0 anaerobicTE=0.0 trainingLoad=60.59

[1] SHOULDER_STABILITY/WEIGHTED_INCLINE_Y_RAISE: 6 sets x 60 reps | max 16.0kg | vol 960.0kg
[2] ROW/FACE_PULL: 5 sets x 50 reps | max 20.0kg | vol 975.0kg
[3] PULL_UP/WIDE_GRIP_LAT_PULLDOWN: 5 sets x 50 reps | max 55.0kg | vol 2650.0kg
[4] ROW/INDOOR_ROW: 1 sets x 447 reps | max 0.0kg | vol 0.0kg
[5] ROW/WEIGHTED_ROW: 10 sets x 100 reps | max 50.0kg | vol 4150.0kg
[6] LEG_CURL/WEIGHTED_LEG_CURL: 5 sets x 50 reps | max 32.5kg | vol 1600.0kg
```

### Detailed Exercise Sets (from exerciseSets API endpoint) — 32 active sets
```
Set  1: ROW/INDOOR_ROW                           | 447 reps x    0.0kg | dur  913.5s
Set  2: ROW/WEIGHTED_ROW                         |  10 reps x   50.0kg | dur   24.9s
Set  3: ROW/WEIGHTED_ROW                         |  10 reps x   50.0kg | dur   25.0s
Set  4: ROW/WEIGHTED_ROW                         |  10 reps x   50.0kg | dur   25.4s
Set  5: ROW/WEIGHTED_ROW                         |  10 reps x   50.0kg | dur   24.1s
Set  6: ROW/WEIGHTED_ROW                         |  10 reps x   50.0kg | dur   25.2s
Set  7: LEG_CURL/WEIGHTED_LEG_CURL               |  10 reps x   30.0kg | dur   28.1s
Set  8: LEG_CURL/WEIGHTED_LEG_CURL               |  10 reps x   32.5kg | dur   29.6s
Set  9: LEG_CURL/WEIGHTED_LEG_CURL               |  10 reps x   32.5kg | dur   30.0s
Set 10: LEG_CURL/WEIGHTED_LEG_CURL               |  10 reps x   32.5kg | dur   29.0s
Set 11: LEG_CURL/WEIGHTED_LEG_CURL               |  10 reps x   32.5kg | dur   29.6s
Set 12: PULL_UP/WIDE_GRIP_LAT_PULLDOWN           |  10 reps x   50.0kg | dur   34.3s
Set 13: PULL_UP/WIDE_GRIP_LAT_PULLDOWN           |  10 reps x   55.0kg | dur   32.4s
Set 14: PULL_UP/WIDE_GRIP_LAT_PULLDOWN           |  10 reps x   55.0kg | dur   33.7s
Set 15: PULL_UP/WIDE_GRIP_LAT_PULLDOWN           |  10 reps x   55.0kg | dur   34.4s
Set 16: PULL_UP/WIDE_GRIP_LAT_PULLDOWN           |  10 reps x   50.0kg | dur   35.1s
Set 17: ROW/FACE_PULL                            |  10 reps x   17.5kg | dur   33.4s
Set 18: ROW/FACE_PULL                            |  10 reps x   20.0kg | dur   33.5s
Set 19: ROW/FACE_PULL                            |  10 reps x   20.0kg | dur   33.5s
Set 20: ROW/FACE_PULL                            |  10 reps x   20.0kg | dur   33.8s
Set 21: ROW/FACE_PULL                            |  10 reps x   20.0kg | dur   40.6s
Set 22: SHOULDER_STABILITY/WEIGHTED_INCLINE_Y_RAISE |  10 reps x   16.0kg | dur   25.8s
Set 23: SHOULDER_STABILITY/WEIGHTED_INCLINE_Y_RAISE |  10 reps x   16.0kg | dur   30.4s
Set 24: SHOULDER_STABILITY/WEIGHTED_INCLINE_Y_RAISE |  10 reps x   16.0kg | dur   27.5s
Set 25: SHOULDER_STABILITY/WEIGHTED_INCLINE_Y_RAISE |  10 reps x   16.0kg | dur   28.0s
Set 26: SHOULDER_STABILITY/WEIGHTED_INCLINE_Y_RAISE |  10 reps x   16.0kg | dur   27.2s
Set 27: SHOULDER_STABILITY/WEIGHTED_INCLINE_Y_RAISE |  10 reps x   16.0kg | dur   26.6s
Set 28: ROW/WEIGHTED_ROW                         |  10 reps x   40.0kg | dur   25.7s
Set 29: ROW/WEIGHTED_ROW                         |  10 reps x   35.0kg | dur   25.7s
Set 30: ROW/WEIGHTED_ROW                         |  10 reps x   30.0kg | dur   28.9s
Set 31: ROW/WEIGHTED_ROW                         |  10 reps x   30.0kg | dur   26.0s
Set 32: ROW/WEIGHTED_ROW                         |  10 reps x   30.0kg | dur   28.2s
```

### HR Time In Zones (from API)
```
Zone 1:   2617s (43.6min) | lower bound: 119 bpm
Zone 2:    335s (5.6min) | lower bound: 150 bpm
Zone 3:     97s (1.6min) | lower bound: 156 bpm
Zone 4:      0s (0.0min) | lower bound: 170 bpm
Zone 5:      0s (0.0min) | lower bound: 179 bpm
```

### Raw API Sample (exerciseSets endpoint)
```json
{
  "exercises": [
    {
      "category": "ROW",
      "name": "WEIGHTED_ROW",
      "probability": 100.0
    }
  ],
  "duration": 24.898,
  "repetitionCount": 10,
  "weight": 50000.0,
  "setType": "ACTIVE",
  "startTime": "2026-03-17T15:50:46.0",
  "wktStepIndex": null,
  "messageIndex": null
}
```

### Validation Against Garmin Connect UI

All 32 sets match the Garmin Connect web UI exactly — exercise names, reps, weights, and set ordering are correct.

Key data format findings:
- `weight`: in **grams** (50000.0 = 50.0 kg)
- `duration`: in **seconds** (24.898s)
- `startTime`: ISO string (`2026-03-17T15:50:46.0`)
- Exercise info nested in `exercises[0].category` / `exercises[0].name`

## Changes

Single file: `src/garmin_grafana/garmin_fetch.py` (168 insertions, 3 deletions)

- Modified `get_activity_summary()` to detect and collect strength training activities
- Added `get_strength_training_data()` function using Garmin API endpoints
- Enriched `ActivitySummary` with training effect and set count fields
- Wired into `daily_fetch_write()` under existing `activity` fetch selection

Closes #189
