### PR TITLE
feat: add ACTIVITY_TYPE_FILTER env var to import only specific activity types

### DIFF
--- a/src/garmin_grafana/garmin_fetch.py
+++ b/src/garmin_grafana/garmin_fetch.py
@@ -58,6 +58,7 @@ INFLUXDB_ENDPOINT_IS_HTTP = False if os.getenv("INFLUXDB_ENDPOINT_IS_HTTP") in [
 GARMIN_DEVICENAME_AUTOMATIC = False if GARMIN_DEVICENAME != "Unknown" else True # optional
 UPDATE_INTERVAL_SECONDS = int(os.getenv("UPDATE_INTERVAL_SECONDS", 300)) # optional
 FETCH_SELECTION = os.getenv("FETCH_SELECTION", "daily_avg,sleep,steps,heartrate,stress,breathing,hrv,fitness_age,vo2,activity,race_prediction,body_composition,lifestyle") # additional available values are lactate_threshold,training_status,training_readiness,hill_score,endurance_score,blood_pressure,hydration,solar_intensity which you can add to the list seperated by , without any space
+ACTIVITY_TYPE_FILTER = [t.strip().lower() for t in os.getenv("ACTIVITY_TYPE_FILTER", "").split(",") if t.strip()] # optional, comma-separated list of activity typeKeys to import only specific activity types. Leave empty to import all. Known typeKeys: running,treadmill_running,indoor_running,cycling,indoor_cycling,road_biking,mountain_biking,walking,hiking,mountaineering,strength_training,hiit,indoor_cardio,elliptical,lap_swimming,open_water_swimming,rock_climbing,indoor_climbing,tennis_v2,kayaking_v2,boating_v2,multi_sport,other
 LACTATE_THRESHOLD_SPORTS = os.getenv("LACTATE_THRESHOLD_SPORTS", "RUNNING").upper().split(",") # Garmin currently implements RUNNING, but has provisions for CYCLING, and SWIMMING
 KEEP_FIT_FILES = True if os.getenv("KEEP_FIT_FILES") in ['True', 'true', 'TRUE','t', 'T', 'yes', 'Yes', 'YES', '1'] else False # optional
 FIT_FILE_STORAGE_LOCATION = os.getenv("FIT_FILE_STORAGE_LOCATION", os.path.join(os.path.expanduser("~"), "fit_filestore"))
@@ -635,6 +636,9 @@ def get_activity_summary(date_str):
     activity_with_gps_id_dict = {}
     strength_activity_id_dict = {}
     activity_list = garmin_obj.get_activities_by_date(date_str, date_str)
+    if ACTIVITY_TYPE_FILTER:
+        activity_list = [a for a in activity_list if (a.get('activityType') or {}).get('typeKey', 'Unknown').lower() in ACTIVITY_TYPE_FILTER]
+        logging.info(f"ACTIVITY_TYPE_FILTER active: kept {len(activity_list)} activities matching {ACTIVITY_TYPE_FILTER}")
     for activity in activity_list:
         activity_type_key = (activity.get('activityType') or {}).get('typeKey', "Unknown")
         if activity.get('hasPolyline') or ALWAYS_PROCESS_FIT_FILES: # will process FIT files lacking GPS data if ALWAYS_PROCESS_FIT_FILES is set to True


### PR DESCRIPTION
## Summary

Adds a new optional environment variable `ACTIVITY_TYPE_FILTER` that allows filtering activities by their Garmin `typeKey` during import. This is useful when you want to re-import or import only specific activity types (e.g. only strength training workouts) without reprocessing all other activities.

### Usage

Set the env var as a comma-separated list of typeKeys (case-insensitive):

```env
# Import only strength training activities
ACTIVITY_TYPE_FILTER=strength_training

# Import multiple specific types
ACTIVITY_TYPE_FILTER=strength_training,running,hiking
```

When left empty (default), all activity types are imported as before — no behavior change.

Works well combined with `FETCH_SELECTION=activity` for a targeted re-import.

### Known Garmin Activity typeKeys

| Category | typeKey |
|---|---|
| **Running** | `running`, `treadmill_running`, `indoor_running` |
| **Cycling** | `cycling`, `indoor_cycling`, `road_biking`, `mountain_biking` |
| **Walking / Hiking** | `walking`, `hiking`, `mountaineering` |
| **Strength / Cardio** | `strength_training`, `hiit`, `indoor_cardio`, `elliptical` |
| **Swimming** | `lap_swimming`, `open_water_swimming` |
| **Climbing** | `rock_climbing`, `indoor_climbing` |
| **Water Sports** | `kayaking_v2`, `boating_v2` |
| **Racquet** | `tennis_v2` |
| **Other** | `multi_sport`, `auto_racing`, `driving_general`, `other` |

> **Note:** This list was obtained from real Garmin data in InfluxDB. Additional typeKeys may exist depending on your Garmin device and activities.

### Changes

- **`garmin_fetch.py`**: Added `ACTIVITY_TYPE_FILTER` env var parsing and filtering logic in `get_activity_summary()`
