### PR TITLE
Add HR Zone boundaries to the ActivitySummary to allow coloring of HR charts based on HR zones.

### DIFF
--- a/src/garmin_grafana/garmin_fetch.py
+++ b/src/garmin_grafana/garmin_fetch.py
@@ -656,8 +656,11 @@ def get_activity_summary(date_str):
             activity_id = activity.get('activityId')
             hr_zones_data = garmin_obj.get_activity_hr_in_timezones(activity_id)
             hr_zone_boundaries = [None] * 5
-            for zone in hr_zones_data:
-                hr_zone_boundaries[int(zone.get('zoneNumber')) - 1] = zone.get('zoneLowBoundary')
+            if hr_zones_data:
+                for zone in hr_zones_data:
+                    hr_zone_boundaries[int(zone.get('zoneNumber')) - 1] = zone.get('zoneLowBoundary')
+            else:
+                logging.warning(f"No HR zone data found for activity: {activity_id}")
 
             points_list.append({
                 "measurement":  "ActivitySummary",

--- a/src/garmin_grafana/garmin_fetch.py
+++ b/src/garmin_grafana/garmin_fetch.py
@@ -653,6 +653,12 @@ def get_activity_summary(date_str):
                 'activityName': activity.get('activityName'),
             }
         if "startTimeGMT" in activity: # "startTimeGMT" should be available for all activities (fix #13)
+            activity_id = activity.get('activityId')
+            hr_zones_data = garmin_obj.get_activity_hr_in_timezones(activity_id)
+            hr_zone_boundaries = [None] * 5
+            for zone in hr_zones_data:
+                hr_zone_boundaries[int(zone.get('zoneNumber')) - 1] = zone.get('zoneLowBoundary')
+
             points_list.append({
                 "measurement":  "ActivitySummary",
                 "time": datetime.strptime(activity["startTimeGMT"], "%Y-%m-%d %H:%M:%S").replace(tzinfo=pytz.UTC).isoformat(),
@@ -663,7 +669,7 @@ def get_activity_summary(date_str):
                     "ActivitySelector": datetime.strptime(activity["startTimeGMT"], "%Y-%m-%d %H:%M:%S").replace(tzinfo=pytz.UTC).strftime('%Y%m%dT%H%M%SUTC-') + (activity.get('activityType') or {}).get('typeKey', "Unknown")
                 },
                 "fields": {
-                    "Activity_ID": activity.get('activityId'),
+                    "Activity_ID": activity_id,
                     'Device_ID': activity.get('deviceId'),
                     'activityName': activity.get('activityName'),
                     'description': activity.get('description'),
@@ -687,6 +693,11 @@ def get_activity_summary(date_str):
                     'hrTimeInZone_3': int(val) if (val := activity.get('hrTimeInZone_3')) is not None else None,
                     'hrTimeInZone_4': int(val) if (val := activity.get('hrTimeInZone_4')) is not None else None,
                     'hrTimeInZone_5': int(val) if (val := activity.get('hrTimeInZone_5')) is not None else None,
+                    'hrZoneLowBoundary_1': hr_zone_boundaries[0],
+                    'hrZoneLowBoundary_2': hr_zone_boundaries[1],
+                    'hrZoneLowBoundary_3': hr_zone_boundaries[2],
+                    'hrZoneLowBoundary_4': hr_zone_boundaries[3],
+                    'hrZoneLowBoundary_5': hr_zone_boundaries[4],
                     'aerobicTrainingEffect': activity.get('aerobicTrainingEffect'),
                     'anaerobicTrainingEffect': activity.get('anaerobicTrainingEffect'),
                     'activityTrainingLoad': activity.get('activityTrainingLoad'),


### PR DESCRIPTION
Adding HR Zone data from Garmin to the activity summary allows to query the HR Zone lower boundaries at the time of the activity, like:

SELECT "hrZoneLowBoundary_1", "hrZoneLowBoundary_2", "hrZoneLowBoundary_3", "hrZoneLowBoundary_4", "hrZoneLowBoundary_5" FROM "ActivitySummary" WHERE ActivitySelector = '20260330T115634UTC-running'

<img width="1597" height="483" alt="image" src="https://github.com/user-attachments/assets/de2516c3-bd5d-4964-a00e-aa04fce7d241" />

This data allows to create colored charts based on the HR zones using "Config from query results" transformation by setting the HR Zone boundaries as thresholds:

<img width="1593" height="352" alt="image" src="https://github.com/user-attachments/assets/46e305c3-8dd4-4cba-a731-f0ed9538ebc2" />


