### PR TITLE
Missing org parameter in InfluxDB v3 connection causing 404 Not Found

### DIFF
--- a/src/garmin_grafana/garmin_fetch.py
+++ b/src/garmin_grafana/garmin_fetch.py
@@ -41,7 +41,7 @@ INFLUXDB_USERNAME = os.getenv("INFLUXDB_USERNAME", 'influxdb_username') # Requir
 INFLUXDB_PASSWORD = os.getenv("INFLUXDB_PASSWORD", 'influxdb_access_password') # Required
 INFLUXDB_DATABASE = os.getenv("INFLUXDB_DATABASE", 'GarminStats') # Required
 INFLUXDB_V3_ACCESS_TOKEN = os.getenv("INFLUXDB_V3_ACCESS_TOKEN",'') # InfluxDB V3 Access token, required only for InfluxDB V3
-INFLUXDB_ORG = org=os.getenv("INFLUXDB_ORG")
+INFLUXDB_ORG = os.getenv("INFLUXDB_ORG", 'default') # required only for InfluxDB V3 
 TOKEN_DIR = os.getenv("TOKEN_DIR", "~/.garminconnect") # optional
 GARMINCONNECT_EMAIL = os.environ.get("GARMINCONNECT_EMAIL", None) # optional, asks in prompt on run if not provided
 GARMINCONNECT_PASSWORD = base64.b64decode(os.getenv("GARMINCONNECT_BASE64_PASSWORD")).decode("utf-8") if os.getenv("GARMINCONNECT_BASE64_PASSWORD") != None else None # optional, asks in prompt on run if not provided

--- a/src/garmin_grafana/garmin_fetch.py
+++ b/src/garmin_grafana/garmin_fetch.py
@@ -41,6 +41,7 @@ INFLUXDB_USERNAME = os.getenv("INFLUXDB_USERNAME", 'influxdb_username') # Requir
 INFLUXDB_PASSWORD = os.getenv("INFLUXDB_PASSWORD", 'influxdb_access_password') # Required
 INFLUXDB_DATABASE = os.getenv("INFLUXDB_DATABASE", 'GarminStats') # Required
 INFLUXDB_V3_ACCESS_TOKEN = os.getenv("INFLUXDB_V3_ACCESS_TOKEN",'') # InfluxDB V3 Access token, required only for InfluxDB V3
+INFLUXDB_ORG = org=os.getenv("INFLUXDB_ORG")
 TOKEN_DIR = os.getenv("TOKEN_DIR", "~/.garminconnect") # optional
 GARMINCONNECT_EMAIL = os.environ.get("GARMINCONNECT_EMAIL", None) # optional, asks in prompt on run if not provided
 GARMINCONNECT_PASSWORD = base64.b64decode(os.getenv("GARMINCONNECT_BASE64_PASSWORD")).decode("utf-8") if os.getenv("GARMINCONNECT_BASE64_PASSWORD") != None else None # optional, asks in prompt on run if not provided
@@ -93,6 +94,7 @@ try:
             influxdbclient = InfluxDBClient3(
             host=f"http://{INFLUXDB_HOST}:{INFLUXDB_PORT}",
             token=INFLUXDB_V3_ACCESS_TOKEN,
+            org=INFLUXDB_ORG
             database=INFLUXDB_DATABASE
             )
     else:
@@ -103,6 +105,7 @@ try:
             influxdbclient = InfluxDBClient3(
             host=f"https://{INFLUXDB_HOST}:{INFLUXDB_PORT}",
             token=INFLUXDB_V3_ACCESS_TOKEN,
+            org=INFLUXDB_ORG,
             database=INFLUXDB_DATABASE
             )
     demo_point = {


### PR DESCRIPTION
Hello,

Thank you for this great project! While setting up the script with InfluxDB v3 (INFLUXDB_VERSION=3), I ran into a connection issue resulting in a 404 Not Found error.

The Bug:
In src/garmin_grafana/garmin_fetch.py (around line 100-110), the InfluxDBClient3 is instantiated without the org parameter in both the HTTP and HTTPS blocks. Because of this, the client ignores the user's actual organization and defaults to looking for an organization named "default", which causes InfluxDB to reject the connection: {"code":"not found","message":"organization name \"default\" not found"}

The Fix:
I added INFLUXDB_ORG=os.getenv("INFLUXDB_ORG") in constant delaration block and org=INFLUXDB_ORG to the InfluxDBClient3 parameters so the script properly fetches and sends the organization defined in the environment variables.