### PR TITLE
Remove 'mean' calculated field from intraday steps panel

### DIFF
--- a/Grafana_Dashboard/Garmin-Grafana-Dashboard.json
+++ b/Grafana_Dashboard/Garmin-Grafana-Dashboard.json
@@ -1196,8 +1196,7 @@
         "legend": {
           "calcs": [
             "min",
-            "max",
-            "mean"
+            "max"
           ],
           "displayMode": "table",
           "placement": "bottom",


### PR DESCRIPTION
In panel Intraday Steps, the calculated field "mean" does not represent anything (because it's a cumulative sum since midnight.

This PR removes it, I've tested it locally by importing the updated json file. See capture below:
<img width="1345" height="303" alt="image" src="https://github.com/user-attachments/assets/fc7c4579-54b2-4b54-a1b3-7b2f76d3de59" />
