### PR TITLE
docs: add correct Proxmox LXC install command via community-scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,14 @@ Enter the Garmin Connect credentials when prompted and you should be all up and 
 
 That should be everything you need for now! The script will be running in the background as long as your machine is up. After a restart, make sure to open docker desktop if you are on windows (if it does not start automatically) so that the containers get booted up as well. For Linux, everything should restart reliably after a reboot. If you are having issues, make sure the docker daemon is running and check the container status with `docker ps` command
 
+#### Proxmox LXC Install (via community-scripts)
+
+If you are running Proxmox, you can deploy this project as an LXC container using the [community-scripts/ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) helper. Run the following command from your Proxmox host shell:
+
+```bash
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/ct/garmin-grafana.sh)"
+```
+
 ## Manual Install with Docker (Recommended if you understand linux concepts)
 
 > [!IMPORTANT]


### PR DESCRIPTION
## Summary

The [community-scripts/ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) project has a Proxmox LXC installer for garmin-grafana, but the README had no mention of it. Users who found the script independently were using the wrong path (`/tools/addon/garmin-grafana.sh`) which returns a 404 — the script actually lives at `ct/garmin-grafana.sh`.

- Adds a **Proxmox LXC Install** subsection under the automatic install section
- Documents the correct one-liner: `bash -c "$(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/ct/garmin-grafana.sh)"`
- Links to the ProxmoxVED repo for context

## Test plan

- [x] Verify the curl URL resolves (not 404): `curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/ct/garmin-grafana.sh`
- [x] Check README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)