### PR TITLE
fix: bump garminconnect to 0.3.6 (email-MFA login fix) and harden credential login fallback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = "==3.13.*"
 dependencies = [
     "dotenv==0.9.9",
     "fitparse==1.2.0",
-    "garminconnect==0.3.3",
+    "garminconnect==0.3.6",
     "influxdb==5.3.2",
     "influxdb3-python==0.12.0",
     "pandas==2.2.3",

--- a/src/garmin_grafana/garmin_fetch.py
+++ b/src/garmin_grafana/garmin_fetch.py
@@ -44,8 +44,13 @@ INFLUXDB_V3_ACCESS_TOKEN = os.getenv("INFLUXDB_V3_ACCESS_TOKEN",'') # InfluxDB V
 INFLUXDB_ORG = os.getenv("INFLUXDB_ORG", 'default') # required only for InfluxDB V3 
 TOKEN_DIR = os.getenv("TOKEN_DIR", "~/.garminconnect") # optional
 GARMINCONNECT_EMAIL = (os.environ.get("GARMINCONNECT_EMAIL") or "").strip() or None # optional, asks in prompt on run if not provided
-_garmin_pw_b64 = os.getenv("GARMINCONNECT_BASE64_PASSWORD")
-GARMINCONNECT_PASSWORD = base64.b64decode(_garmin_pw_b64).decode("utf-8").strip() if _garmin_pw_b64 else None # optional, asks in prompt on run if not provided
+_garmin_pw_b64 = (os.getenv("GARMINCONNECT_BASE64_PASSWORD") or "").strip() or None
+if os.getenv("GARMINCONNECT_PASSWORD") and not _garmin_pw_b64:
+    logging.warning("GARMINCONNECT_PASSWORD ENV variable is not supported and will be ignored - please provide your password Base64 encoded via GARMINCONNECT_BASE64_PASSWORD instead (see README)")
+try:
+    GARMINCONNECT_PASSWORD = base64.b64decode(_garmin_pw_b64, validate=True).decode("utf-8").strip() if _garmin_pw_b64 else None # optional, asks in prompt on run if not provided
+except (ValueError, UnicodeDecodeError) as err: # binascii.Error is a subclass of ValueError
+    raise ValueError("GARMINCONNECT_BASE64_PASSWORD does not contain valid Base64 encoded data - encode your password first (e.g. printf '%s' 'your_password' | base64) and use that value. A plaintext password here silently decodes to garbage and leads to misleading 401 login errors") from err
 GARMINCONNECT_IS_CN = True if os.getenv("GARMINCONNECT_IS_CN") in ['True', 'true', 'TRUE','t', 'T', 'yes', 'Yes', 'YES', '1'] else False # optional if you are using a Chinese account
 GARMIN_DEVICENAME = os.getenv("GARMIN_DEVICENAME", "Unknown")  # optional, attempts to set the name automatically if not given
 GARMIN_DEVICEID = os.getenv("GARMIN_DEVICEID", None)  # optional, attempts to set the id automatically if not given
@@ -136,6 +141,26 @@ def iter_days(start_date: str, end_date: str):
 
 
 # %%
+class GarminLoginInputUnavailableError(Exception):
+    """Raised when Garmin login requires interactive input but no terminal is attached."""
+
+
+def _prompt(prompt_text):
+    """Read a value interactively, translating a missing/closed stdin (e.g. container
+    started detached with `docker compose up -d`) into a clear, actionable error
+    instead of an unhandled EOFError crash-loop (see issue #233)."""
+    try:
+        return input(prompt_text).strip()
+    except EOFError as err:
+        raise GarminLoginInputUnavailableError(
+            "Garmin login needs interactive input for this step, but no terminal is attached to the container "
+            "(this happens when it is started detached, e.g. with `docker compose up -d`). "
+            "Run the first-time login interactively with `docker compose run --rm garmin-fetch-data` to generate the auth tokens, "
+            "or provide the GARMINCONNECT_EMAIL and GARMINCONNECT_BASE64_PASSWORD ENV variables (password must be Base64 encoded - see README). "
+            "Note : accounts with MFA/2FA enabled always need one interactive run to enter the one-time code."
+        ) from err
+
+
 def garmin_login():
     token_store_expanded = os.path.expanduser(TOKEN_DIR)
     token_store = token_store_expanded
@@ -158,22 +183,34 @@ def garmin_login():
     except (FileNotFoundError, GarminConnectAuthenticationError, GarminConnectConnectionError):
         logging.warning("Session is expired or login information not present/incorrect. You'll need to log in again...login with your Garmin Connect credentials to generate them.")
         try:
-            user_email = (GARMINCONNECT_EMAIL or "").strip() or input("Enter Garminconnect Login e-mail: ").strip()
-            user_password = (GARMINCONNECT_PASSWORD or "").strip() or input("Enter Garminconnect password (characters will be visible): ").strip()
+            if GARMINCONNECT_EMAIL and GARMINCONNECT_PASSWORD:
+                logging.info("Using Garmin Connect credentials provided with the GARMINCONNECT_EMAIL and GARMINCONNECT_BASE64_PASSWORD ENV variables")
+            user_email = GARMINCONNECT_EMAIL or _prompt("Enter Garminconnect Login e-mail: ")
+            user_password = GARMINCONNECT_PASSWORD or _prompt("Enter Garminconnect password (characters will be visible): ")
             garmin = Garmin(
                 email=user_email, password=user_password, is_cn=GARMINCONNECT_IS_CN,
-                prompt_mfa=lambda: input("MFA one-time code (via email or SMS): ").strip(),
+                prompt_mfa=lambda: _prompt("MFA one-time code (via email or SMS): "),
             )
             garmin.login(token_store)
 
             logging.info(f"Oauth tokens stored in '{token_store}' for future use")
             logging.info("login to Garmin Connect successful using credentials and MFA (if enabled). Continuing with current run")
 
+        except GarminLoginInputUnavailableError as err:
+            logging.error(str(err))
+            raise Exception("Garmin login failed : interactive input required but no terminal is attached (see the error above for how to fix this)") from None
+        except GarminConnectTooManyRequestsError as err:
+            logging.error(str(err))
+            raise Exception(
+                "Garmin login failed : rate limited by Garmin (429). Too many login attempts from this IP - "
+                "a crash-looping container with restart: unless-stopped makes this worse by retrying the login on every restart. "
+                "Stop the container, wait a few hours, and retry interactively with `docker compose run --rm garmin-fetch-data`. "
+                "Valid stored tokens are unaffected by this - do not delete the token directory."
+            ) from None
         except (
             FileNotFoundError,
             GarminConnectConnectionError,
             GarminConnectAuthenticationError,
-            GarminConnectTooManyRequestsError,
             requests.exceptions.HTTPError,
         ) as err:
             logging.error(str(err))

--- a/uv.lock
+++ b/uv.lock
@@ -115,7 +115,7 @@ dependencies = [
 requires-dist = [
     { name = "dotenv", specifier = "==0.9.9" },
     { name = "fitparse", specifier = "==1.2.0" },
-    { name = "garminconnect", specifier = "==0.3.3" },
+    { name = "garminconnect", specifier = "==0.3.6" },
     { name = "influxdb", specifier = "==5.3.2" },
     { name = "influxdb3-python", specifier = "==0.12.0" },
     { name = "pandas", specifier = "==2.2.3" },
@@ -123,16 +123,16 @@ requires-dist = [
 
 [[package]]
 name = "garminconnect"
-version = "0.3.3"
+version = "0.3.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "curl-cffi" },
     { name = "requests" },
     { name = "ua-generator" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/d9/7ad240d86453de083f0c460ee328e8209232d9d0ee099dcf49439d90be7a/garminconnect-0.3.3.tar.gz", hash = "sha256:f608193d7a90079fa1fd1d86e8d10e88b871b6ab2500372a9dc48358f8c2d386", size = 52234, upload-time = "2026-04-22T12:57:24.79Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/29/f8e3609f22693020dec65d6285adf12daac459461a09e59dffe12ec7fc08/garminconnect-0.3.6.tar.gz", hash = "sha256:6f90aa282976f7dff880cf53ef4f3ea0d63701fd2a1488c628a66a2a027c2143", size = 61911, upload-time = "2026-06-14T08:05:37.349Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/5a/69af564ff61c87a725e0a6b6ceed4a01569a1caced2c136042c778907244/garminconnect-0.3.3-py3-none-any.whl", hash = "sha256:e11dbbddf20abd60d5c8fbde1e7c688ca175a905237dfec8837ee935a1aca803", size = 47814, upload-time = "2026-04-22T12:57:23.175Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/f9/6d69eb2eab9f62ed7e415a606c5ef63e19f27e561d15d7ac7d651997cfad/garminconnect-0.3.6-py3-none-any.whl", hash = "sha256:e05782ab90e63cb9c023407899e2d12dd18132316fd84394ebecd393809d4ffe", size = 57555, upload-time = "2026-06-14T08:05:36.027Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Follow-up to the debugging in #233 (also relates to #20). Two changes: a `garminconnect` version bump that fixes the current wave of login failures, and hardening of the credential-login fallback path in `garmin_fetch.py`.

### 1. Bump `garminconnect` 0.3.3 → 0.3.6

The pinned 0.3.3 is missing the **email/SMS one-time-code MFA fix** from 0.3.6 ([PR cyberjunky/python-garminconnect#371](https://github.com/cyberjunky/python-garminconnect/pull/371)). On 0.3.3 the widget SSO strategy aborts with

```
widget+cffi failed: Widget login: unexpected title 'GARMIN Authentication Application'
```

instead of prompting for the emailed code (that title is what Garmin returns for email OTP MFA, which is mandatory on newer ECG-capable devices). The login chain then falls through to the portal strategies, which typically end in Cloudflare 429s or a misleading `401 Unauthorized (Invalid Username or Password)` — exactly the recent reports in #233. This also explains the "works with python-garminconnect directly" confusion in that thread: cloning that repo gets master/0.3.6 behaviour, while the published garmin-fetch-data image is frozen at 0.3.3.

The bump also picks up from 0.3.5:
- in-chain token validation + self-healing from poisoned cached tokens (login resilience, upstream #369)
- token store permission hardening — `garmin_tokens.json` was world-readable, [GHSA-wjhr-76vg-2hvc](https://github.com/cyberjunky/python-garminconnect/security/advisories/GHSA-wjhr-76vg-2hvc)

`uv.lock` regenerated with `uv lock`; only `garminconnect` changed (no new transitive deps).

### 2. Fail cleanly when no terminal is attached (no more EOFError crash-loop)

As reported in #233 ([comment](https://github.com/arpanghosh8453/garmin-grafana/issues/233#issuecomment-4897575725)): when tokens are absent/expired and the container runs detached (`docker compose up -d`), `input()` raises an unhandled `EOFError`, the container crash-loops under `restart: unless-stopped`, and every restart re-hits Garmin's login endpoint — escalating the IP rate limiting (429) it was already suffering from.

Now all interactive prompts (email, password, MFA code) go through a small `_prompt()` helper that converts `EOFError` into a clear, actionable error telling the user to either run `docker compose run --rm garmin-fetch-data` once interactively, or set `GARMINCONNECT_EMAIL`/`GARMINCONNECT_BASE64_PASSWORD`.

### 3. Validate `GARMINCONNECT_BASE64_PASSWORD` is actually Base64

`base64.b64decode()` without `validate=True` happily "decodes" many plaintext passwords into garbage bytes, producing misleading `401 Unauthorized` errors that look like Garmin/Cloudflare problems. Now decoded with `validate=True` and a helpful error message on failure. Also logs a warning if someone sets the unsupported `GARMINCONNECT_PASSWORD` variable (a recurring support issue).

### 4. Dedicated 429 error message

Rate-limit failures now explain the wait-and-retry recovery path (and that stored tokens are unaffected) instead of the generic "login failed" text.

## Testing

- `uv sync --locked` + import/param-signature check against 0.3.6 passes; verified the email-MFA title fix is present in the installed lib.
- Smoke-tested `garmin_login()` with a mocked `Garmin` class covering: env credentials used without prompting; detached-container EOF → clean error (email/password prompt and MFA prompt paths); 429 → dedicated message; interactive MFA prompt still works; Base64 validation accepts real Base64 and rejects plaintext-with-spaces.
- Not yet re-tested against live Garmin login from my env (my account currently holds valid tokens generated via the upstream `example.py` workaround; happy to re-test a container build if wanted).

---

Assisted-by: Fable 5
