### PR TITLE
fix: cast ActivityLap Sport field to str to avoid InfluxDB 400 field type conflict

### DIFF
--- a/src/garmin_grafana/garmin_fetch.py
+++ b/src/garmin_grafana/garmin_fetch.py
@@ -1159,7 +1159,7 @@ def fetch_activity_GPS(activityIDdict): # Uses FIT file by default, falls back t
                                     "ActivityName": activity_type,
                                     "Activity_ID": activityID,
                                     "Elapsed_Time": lap_record.get('total_elapsed_time', None),
-                                    "Sport": lap_record.get('sport', None),
+                                    "Sport": str(lap_record.get('sport', None)), # Avoid partial write error 400 (same fix as ActivitySession Sport above) see #152#issuecomment-3084539416
                                     "Lengths": lap_record.get('num_lengths', None),
                                     "Length_Index": lap_record.get('first_length_index', None),
                                     "Distance": lap_record.get('total_distance', None),


### PR DESCRIPTION
### Problem

`ActivitySession.Sport` is already cast to `str()` to avoid a partial-write **400 field type conflict** (issue #152), but the identical field in **`ActivityLap`** was left uncast:

```python
# ActivitySession  (already fixed)
"Sport": str(session_record.get('sport', None)), # Avoid partial write error 400 see #152
# ActivityLap  (still unfixed)
"Sport": lap_record.get('sport', None),
```

For **indoor / no-GPS activities** (e.g. jump rope, processed when `ALWAYS_PROCESS_FIT_FILES=True`), the FIT lap record's `sport` comes through as a **numeric code**, whereas GPS activities (e.g. running) yield a **string** like `"running"`. Once a database already holds string `Sport` values in `ActivityLap`, writing the numeric ones fails:

```
partial write: field type conflict: input field "Sport" on measurement
"ActivityLap" is type integer, already exists as type string  dropped=47
```

InfluxDB then **silently drops the whole batch of lap points**, so the per-lap detail for those activities never lands.

### Fix

One-line change mirroring the existing `ActivitySession` fix — cast `ActivityLap.Sport` to `str()` so the field is consistently a string:

```python
"Sport": str(lap_record.get('sport', None)),
```

### How I hit it

`ALWAYS_PROCESS_FIT_FILES=True` on a database that already had running (GPS) laps. Reprocessing an indoor jump-rope activity produced the 400 above and dropped its 47 laps. After the cast, the same reprocessing writes all 47 laps cleanly (numeric sport stored as e.g. `"84"`, coexisting with `"running"`).

### Scope

Single field cast; no schema or behavioural change for existing string values.
