### PR TITLE
fix: handle list response in get_solar_intensity to prevent bulk-update crash

### DIFF
--- a/src/garmin_grafana/garmin_fetch.py
+++ b/src/garmin_grafana/garmin_fetch.py
@@ -1541,8 +1541,16 @@ def get_solar_intensity(date_str):
         return points_list
 
     si_all = garmin_obj.get_device_solar_data(GARMIN_DEVICEID, date_str) or {}
-    if len(si_all.get('solarDailyDataDTOs', [])) > 0:
-        si_list = si_all['solarDailyDataDTOs'][0].get('solarInputReadings', [])
+    # Garmin occasionally returns a list instead of the expected dict on some dates;
+    # normalize to the DTO list defensively to avoid "AttributeError: 'list' object has no attribute 'get'"
+    if isinstance(si_all, dict):
+        solar_dtos = si_all.get('solarDailyDataDTOs', [])
+    elif isinstance(si_all, list):
+        solar_dtos = si_all
+    else:
+        solar_dtos = []
+    if len(solar_dtos) > 0 and isinstance(solar_dtos[0], dict):
+        si_list = solar_dtos[0].get('solarInputReadings', [])
         for si_measurement in si_list:
             data_fields = {
                 'solarUtilization': si_measurement.get('solarUtilization', None),


### PR DESCRIPTION
### Problem

`get_solar_intensity()` assumes `get_device_solar_data()` returns a dict:

```python
si_all = garmin_obj.get_device_solar_data(GARMIN_DEVICEID, date_str) or {}
if len(si_all.get('solarDailyDataDTOs', [])) > 0:
```

On some dates Garmin returns a **`list`** instead. The `or {}` guard only covers `None`/empty (falsy) values — a **non-empty list is truthy**, so it passes straight through to `si_all.get(...)` and crashes the whole run:

```
File ".../garmin_fetch.py", line 1544, in get_solar_intensity
    if len(si_all.get('solarDailyDataDTOs', [])) > 0:
AttributeError: 'list' object has no attribute 'get'
```

This is fatal during a bulk backfill: one bad date aborts the entire date range. I hit it on `2026-07-08` while backfilling a solar-capable device (Fenix 7 Pro Solar) with `solar_intensity` in `FETCH_SELECTION`.

### Fix

Normalize the response to the DTO list before indexing, handling both the dict and list shapes (and guarding the element access):

```python
if isinstance(si_all, dict):
    solar_dtos = si_all.get('solarDailyDataDTOs', [])
elif isinstance(si_all, list):
    solar_dtos = si_all
else:
    solar_dtos = []
if len(solar_dtos) > 0 and isinstance(solar_dtos[0], dict):
    si_list = solar_dtos[0].get('solarInputReadings', [])
```

The dict path is unchanged; the list path no longer crashes; anything unexpected degrades to "no solar data for this date" instead of aborting the run. Verified by re-running the same 30-day backfill end-to-end with zero errors.
