### PR TITLE
Fix issue 239 nonetype parsing

### DIFF
--- a/src/garmin_grafana/garmin_fetch.py
+++ b/src/garmin_grafana/garmin_fetch.py
@@ -832,9 +832,9 @@ def get_strength_training_data(strength_activity_id_dict):
                 category = exercise_info.get('category', 'UNKNOWN')
                 exercise_name = exercise_info.get('name', '')
                 exercise_label = f"{category}/{exercise_name}" if exercise_name else category
-                weight_g = float(exercise.get('weight', 0) or 0)
+                weight_g = safe_float(exercise.get('weight'))
                 weight_kg = weight_g / 1000.0
-                duration_s = float(exercise.get('duration', 0) or 0)
+                duration_s = safe_float(exercise.get('duration'))
                 start_ts = exercise.get('startTime')
                 if start_ts:
                     set_time = datetime.strptime(start_ts.split('.')[0], "%Y-%m-%dT%H:%M:%S").replace(tzinfo=pytz.UTC).isoformat()
@@ -847,8 +847,8 @@ def get_strength_training_data(strength_activity_id_dict):
                     "SetOrder": int(exercise.get('setOrder', set_counter)),
                     "SetType": set_type,
                     "Reps": safe_int(exercise.get('repetitionCount')),
-                    "Weight_kg": safe_int(weight_kg),
-                    "Duration_s": safe_int(duration_s),
+                    "Weight_kg": weight_kg,
+                    "Duration_s": duration_s,
                 }
                 exercise_set_points.append({
                     "measurement": "StrengthExerciseSet",

--- a/src/garmin_grafana/garmin_fetch.py
+++ b/src/garmin_grafana/garmin_fetch.py
@@ -207,6 +207,24 @@ def write_points_to_influxdb(points):
             logging.info("Success : updated influxDB database with new points")
     except (InfluxDBClientError, InfluxDBError) as err:
         logging.error("Write failed : Unable to connect with database! " + str(err))
+# %%
+def safe_int(value):
+    """Safely cast Garmin API values to integer, defaulting to 0 for missing or string values."""
+    if value is None:
+        return 0
+    try:
+        return int(float(value))
+    except (ValueError, TypeError):
+        return 0
+# %%
+def safe_float(value):
+    """Safely cast Garmin API values to float, defaulting to 0.0 for missing or string values."""
+    if not value:
+        return 0.0
+    try:
+        return float(value)
+    except (ValueError, TypeError):
+        return 0.0
 
 # %%
 def get_daily_stats(date_str):
@@ -828,9 +846,9 @@ def get_strength_training_data(strength_activity_id_dict):
                     "ActivityName": activity_name,
                     "SetOrder": int(exercise.get('setOrder', set_counter)),
                     "SetType": set_type,
-                    "Reps": int(exercise.get('repetitionCount', 0)),
-                    "Weight_kg": weight_kg,
-                    "Duration_s": duration_s,
+                    "Reps": safe_int(exercise.get('repetitionCount')),
+                    "Weight_kg": safe_int(weight_kg),
+                    "Duration_s": safe_int(duration_s),
                 }
                 exercise_set_points.append({
                     "measurement": "StrengthExerciseSet",


### PR DESCRIPTION
This PR implements a `safe_int` and `safe_float` fallback to gracefully handle `None` values and string anomalies (like "repetitionCount") returned by the Garmin API. 

Resolves #239.