### PR TITLE
fix: cast Sport field to str in ActivityLap to prevent field type conflict

### DIFF
--- a/src/garmin_grafana/garmin_fetch.py
+++ b/src/garmin_grafana/garmin_fetch.py
@@ -1159,7 +1159,7 @@ def fetch_activity_GPS(activityIDdict): # Uses FIT file by default, falls back t
                                     "ActivityName": activity_type,
                                     "Activity_ID": activityID,
                                     "Elapsed_Time": lap_record.get('total_elapsed_time', None),
-                                    "Sport": lap_record.get('sport', None),
+                                    "Sport": str(lap_record.get('sport', None)),
                                     "Lengths": lap_record.get('num_lengths', None),
                                     "Length_Index": lap_record.get('first_length_index', None),
                                     "Distance": lap_record.get('total_distance', None),


### PR DESCRIPTION
## Problem

The `ActivityLap` measurement's `Sport` field is written without type coercion. When Garmin's API returns `Sport` as an integer (e.g. `64`) rather than a string, InfluxDB rejects the write with:

```
partial write: field type conflict: input field "Sport" on measurement "ActivityLap" is type integer, already exists as type string dropped=N
```

(or the inverse, depending on which type was written first)

## Fix

Apply the same `str()` cast already used for the `ActivitySession` record at line 1109 — which even has a comment referencing issue #152 about this exact problem — to the `ActivityLap` lap record.

```python
# Before
"Sport": lap_record.get('sport', None),

# After
"Sport": str(lap_record.get('sport', None)),
```

## Tested

Reproduced locally — the error appeared consistently before this change and resolved after. The fix was verified against live data where Garmin returns `Sport` as an integer for padel/paddelball sessions.

---

**AI usage note:** I did use Copilot to help navigate the codebase, but I identified the bug myself by reading through the code and seeing that line 1109 already had the `str()` fix with a comment referencing [#152](https://github.com/arpanghosh8453/garmin-grafana/issues/152). The lap record at 1162 was just missed. I reproduced the error locally, verified the fix resolved it, and understand exactly what the change does.