### PR TITLE
Unit is centimeters when bulk export

### DIFF
--- a/src/garmin_grafana/garmin_bulk_importer.py
+++ b/src/garmin_grafana/garmin_bulk_importer.py
@@ -204,6 +204,14 @@ class GarminBulkExport:
                 a["elevationGain"] = a["elevationGain"] / 100
             if a.get("elevationLoss") is not None:
                 a["elevationLoss"] = a["elevationLoss"] / 100
+            # Bulk export stores duration fields in milliseconds,
+            # but the live API expects seconds.
+            if a.get("duration") is not None:
+                a["duration"] = a["duration"] / 1000
+            if a.get("elapsedDuration") is not None:
+                a["elapsedDuration"] = a["elapsedDuration"] / 1000
+            if a.get("movingDuration") is not None:
+                a["movingDuration"] = a["movingDuration"] / 1000
         logging.info("Loading %d activities", len(activities))
         return sorted(activities, key=lambda o: o["startTimeGMT"])
 
@@ -453,9 +461,14 @@ class GarminBulkExport:
                     best_delta = delta
 
         if not best_match:
-            self.fail(
+            logging.warning(
                 f"No matching FIT file found for activityId={activityId} "
-                f"({activity_start.isoformat()})"
+                f"({activity_start.isoformat()}) - this activity likely has no "
+                f"associated device FIT file (e.g. manual entry or multi-sport "
+                f"parent activity). Skipping GPS/lap/session data for it."
+            )
+            raise FileNotFoundError(
+                f"No matching FIT file found for activityId={activityId}"
             )
 
         logging.info(

--- a/src/garmin_grafana/garmin_bulk_importer.py
+++ b/src/garmin_grafana/garmin_bulk_importer.py
@@ -196,7 +196,14 @@ class GarminBulkExport:
             a["averageSpeed"] = a.get("avgSpeed")
             a["maxHR"] = a.get("maxHr")
             a["averageHR"] = a.get("avgHr")
-
+            # Bulk export stores distance/elevation in centimeters,
+            # but the live API (and garmin_fetch.py) expects meters.
+            if a.get("distance") is not None:
+                a["distance"] = a["distance"] / 100
+            if a.get("elevationGain") is not None:
+                a["elevationGain"] = a["elevationGain"] / 100
+            if a.get("elevationLoss") is not None:
+                a["elevationLoss"] = a["elevationLoss"] / 100
         logging.info("Loading %d activities", len(activities))
         return sorted(activities, key=lambda o: o["startTimeGMT"])
 


### PR DESCRIPTION
When retrieving data via the API, the unit is meters; for files obtained through bulk export, the unit is centimeters.
It affects not only distance but also altitude.

Also duration has same problem.
It is milliseconds.

<from>
Running over 200 km in a single activity—that’s impossible.

```
> select "distance" from "ActivitySummary" where "distance" > 200000
name: ActivitySummary
time                distance
----                --------
1767693793000000000 945733.0078125
1767780160000000000 670108.0078125
1767953708000000000 700668.994140625
1768002706000000000 2011794.921875
1768087381000000000 352526.0009765625
1768094699000000000 300242.9931640625
1768299670000000000 767808.984375
1768471122000000000 802545.01953125
1768607942000000000 2120181.0546875
1768695609000000000 789225
```

<to>
There are no activities that take place over a distance exceeding 200 km.

```
> select "distance" from "ActivitySummary" where "distance" > 200000
> 
```