### PR TITLE
Fix error impact for bulk import

### DIFF
--- a/src/garmin_grafana/garmin_bulk_importer.py
+++ b/src/garmin_grafana/garmin_bulk_importer.py
@@ -204,6 +204,14 @@ class GarminBulkExport:
                 a["elevationGain"] = a["elevationGain"] / 100
             if a.get("elevationLoss") is not None:
                 a["elevationLoss"] = a["elevationLoss"] / 100
+            # Bulk export stores duration fields in milliseconds,
+            # but the live API expects seconds.
+            if a.get("duration") is not None:
+                a["duration"] = a["duration"] / 1000
+            if a.get("elapsedDuration") is not None:
+                a["elapsedDuration"] = a["elapsedDuration"] / 1000
+            if a.get("movingDuration") is not None:
+                a["movingDuration"] = a["movingDuration"] / 1000
         logging.info("Loading %d activities", len(activities))
         return sorted(activities, key=lambda o: o["startTimeGMT"])
 
@@ -453,9 +461,14 @@ class GarminBulkExport:
                     best_delta = delta
 
         if not best_match:
-            self.fail(
+            logging.warning(
                 f"No matching FIT file found for activityId={activityId} "
-                f"({activity_start.isoformat()})"
+                f"({activity_start.isoformat()}) - this activity likely has no "
+                f"associated device FIT file (e.g. manual entry or multi-sport "
+                f"parent activity). Skipping GPS/lap/session data for it."
+            )
+            raise FileNotFoundError(
+                f"No matching FIT file found for activityId={activityId}"
             )
 
         logging.info(

--- a/src/garmin_grafana/garmin_bulk_importer.py
+++ b/src/garmin_grafana/garmin_bulk_importer.py
@@ -453,9 +453,14 @@ class GarminBulkExport:
                     best_delta = delta
 
         if not best_match:
-            self.fail(
+            logging.warning(
                 f"No matching FIT file found for activityId={activityId} "
-                f"({activity_start.isoformat()})"
+                f"({activity_start.isoformat()}) - this activity likely has no "
+                f"associated device FIT file (e.g. manual entry or multi-sport "
+                f"parent activity). Skipping GPS/lap/session data for it."
+            )
+            raise FileNotFoundError(
+                f"No matching FIT file found for activityId={activityId}"
             )
 
         logging.info(

--- a/src/garmin_grafana/garmin_bulk_importer.py
+++ b/src/garmin_grafana/garmin_bulk_importer.py
@@ -196,7 +196,14 @@ class GarminBulkExport:
             a["averageSpeed"] = a.get("avgSpeed")
             a["maxHR"] = a.get("maxHr")
             a["averageHR"] = a.get("avgHr")
-
+            # Bulk export stores distance/elevation in centimeters,
+            # but the live API (and garmin_fetch.py) expects meters.
+            if a.get("distance") is not None:
+                a["distance"] = a["distance"] / 100
+            if a.get("elevationGain") is not None:
+                a["elevationGain"] = a["elevationGain"] / 100
+            if a.get("elevationLoss") is not None:
+                a["elevationLoss"] = a["elevationLoss"] / 100
         logging.info("Loading %d activities", len(activities))
         return sorted(activities, key=lambda o: o["startTimeGMT"])
 


### PR DESCRIPTION
This PR is based on #278. Since the initial commits overlap. The diff will automatically clean up once the previous PR is merged.

The entire process comes to a complete halt because the FIT file corresponding to a single activity cannot be found.
`GarminBulkExport.download_activity()` raises a custom `GarminBulkImporterError` (via `self.fail()`).

Modify the relevant section within `download_activity()` to raise a `FileNotFoundError` instead of calling `self.fail()`.

Error:
...
Traceback (most recent call last):
  File "/app/garmin_grafana/garmin_bulk_importer.py", line 532, in <module>
    garmin_fetch.fetch_write_bulk(args.start_date, args.end_date)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/garmin_grafana/garmin_fetch.py", line 1772, in fetch_write_bulk
    raise err
  File "/app/garmin_grafana/garmin_fetch.py", line 1709, in fetch_write_bulk
    daily_fetch_write(current_date)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/app/garmin_grafana/garmin_fetch.py", line 1689, in daily_fetch_write
    write_points_to_influxdb(fetch_activity_GPS(activity_with_gps_id_dict))
                             ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/garmin_grafana/garmin_fetch.py", line 1046, in fetch_activity_GPS
    zip_data = garmin_obj.download_activity(activityID, dl_fmt=garmin_obj.ActivityDownloadFormat.ORIGINAL)
  File "/app/garmin_grafana/garmin_bulk_importer.py", line 456, in download_activity
    self.fail(
    ~~~~~~~~~^
        f"No matching FIT file found for activityId={activityId} "
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        f"({activity_start.isoformat()})"
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/app/garmin_grafana/garmin_bulk_importer.py", line 158, in fail
    raise GarminBulkImporterError(msg)
GarminBulkImporterError: No matching FIT file found for activityId=22576985116 (2026-04-19T00:52:04+00:00)
...
