### PR TITLE
fix: repair broken Star History chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,4 +369,4 @@ Too complicated to self host just to see your FIT file activity data? What about
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=arpanghosh8453/garmin-grafana&type=Date)](https://www.star-history.com/#arpanghosh8453/garmin-grafana&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=arpanghosh8453/garmin-grafana&type=Date)](https://star-history.dera.page/#arpanghosh8453/garmin-grafana&Date)


### PR DESCRIPTION
The Star History chart in the README is currently broken because the stargazer API it relies on has been restricted by GitHub, so the chart no longer renders. This change points the chart to a working alternative that requires no API token, restoring the stargazer display. Note: the badge is left untouched.